### PR TITLE
fix: restore pydantic orm compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,158 @@
-# 3333
+# Anime Quiz App
+
+這個專案是一個在局域網內使用的動漫歌曲猜題遊戲。後端由 FastAPI 提供房間、玩家、答題與題庫管理，前端使用 React (Vite) 呈現主持人與玩家的互動畫面。以下以「一步一步」的方式帶你完成環境設定與基本操作。
+
+---
+
+## 0. 懶人包：最快的使用流程
+
+1. **準備兩個終端機視窗**（一個跑後端、一個跑前端）。
+2. **第一次使用時**請先依序執行下列指令：
+
+   ```bash
+   # 視窗 A：macOS / Linux 的後端啟動流程
+   cd /你的專案路徑
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r backend/requirements.txt
+   export ADMIN_TOKEN=changeme  # 記得換成你自己的密鑰
+   uvicorn backend.app.main:app --reload --host 0.0.0.0 --port 8000
+   ```
+
+   ```powershell
+   # 視窗 B：Windows PowerShell 中啟動前端
+   cd C:\你的\專案\frontend
+   npm install
+   npm run dev -- --host
+   ```
+
+   > Windows 啟動虛擬環境請改用 `.venv\Scripts\Activate.ps1`，其餘指令相同；若使用 cmd，則輸入 `.venv\Scripts\activate.bat`。
+
+3. 當後端看到 `http://0.0.0.0:8000`（或終端機顯示你的區網 IP）、前端看到 `http://127.0.0.1:5173`/`http://<你的 IP>:5173` 時就代表服務已經運作。
+4. 開啟瀏覽器造訪 `http://localhost:5173`，或在其他裝置輸入 `http://<你的 IP>:5173` 加入。前端會自動改用同一台主機的 `8000` 埠作為 API 位址。
+
+> 之後再次啟動時，只要重新執行步驟 1、5（啟動後端）與步驟 1、6（啟動前端），不需要重新安裝套件。
+
+---
+
+## 0.5 遊戲畫面怎麼操作？
+
+1. 首頁輸入暱稱並建立房間；畫面會顯示要分享給朋友的房間碼。
+2. 其他玩家輸入暱稱與相同房間碼加入。系統最多允許 8 名玩家，也可以只有你自己練習。
+3. 房主在題庫中挑選歌曲或按「隨機播放」，題目會透過 YouTube 播放器從頭播放。
+4. 歌曲播放時輸入動畫名稱作答；第一個達到 80% 相似度的人立即得 1 分並揭示正確答案。
+5. 若所有玩家都按下「跳過」，這題不計分並自動換到下一首。
+6. 有人達到房主設定的目標分數後，當局結束並顯示排行榜，可選擇直接開始下一局。
+
+---
+
+## 1. 準備環境
+
+1. 安裝 **Python 3.11 以上**。
+2. 安裝 **Node.js 18 以上**（會附帶 npm）。
+3. 建議在一台電腦上執行後端與前端，其他玩家以同一個區網的瀏覽器連線即可。
+
+---
+
+## 2. 建立與啟用 Python 虛擬環境
+
+在專案根目錄開啟終端機，依序輸入：
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows 使用 .venv\Scripts\activate
+```
+
+看到提示字元前面多了一個 `(.venv)` 就代表虛擬環境啟用了。
+
+---
+
+## 3. 安裝並啟動後端 (FastAPI)
+
+1. 安裝套件：
+
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+2. 設定管理者密鑰（供審核歌曲時使用，可自行替換）：
+
+   ```bash
+   export ADMIN_TOKEN=changeme  # Windows 可改用 set 或 PowerShell 的 $Env:ADMIN_TOKEN
+   ```
+
+3. （選擇性）若想改用其他資料庫，可在啟動前設定 `DATABASE_URL`；預設會在根目錄產生 `anime_quiz.db` 的 SQLite 檔。
+
+4. 啟動伺服器：
+
+   ```bash
+   uvicorn backend.app.main:app --reload --host 0.0.0.0 --port 8000
+   ```
+
+   終端機出現 `Uvicorn running on http://0.0.0.0:8000`（或顯示實際區網 IP）代表後端啟動成功，其他裝置才能順利連線。
+
+5. 測試健康檢查：在另一個終端機或瀏覽器開啟 `http://localhost:8000/health`，應會看到 `{"status":"ok"}`。
+
+---
+
+## 4. 安裝並啟動前端 (React / Vite)
+
+1. **另開一個終端機視窗**，進入 `frontend/` 資料夾。
+2. 安裝套件：
+
+   ```bash
+   npm install
+   ```
+
+3. 啟動開發伺服器：
+
+   ```bash
+   npm run dev -- --host
+   ```
+
+   Vite 預設會顯示「Local: http://127.0.0.1:5173」與「Network: http://<你的 IP>:5173」。
+
+4. 在瀏覽器輸入 `http://localhost:5173`（或區網內其他裝置可用 Network URL）。若要改用不同的後端主機/埠，仍可透過 `VITE_API_BASE_URL` 環境變數覆蓋預設值。
+
+   > 預設情況下，前端會以你目前開啟頁面所使用的主機名稱，加上 `8000` 埠作為 API 位址，因此在同一台機器啟動後端與前端時不用額外設定；若後端跑在另一台機器或不同埠才需要手動指定。
+
+---
+
+## 5. 基本操作流程
+
+1. 進入首頁後，輸入暱稱並建立房間；房主會取得房間碼。
+2. 其他玩家輸入相同房間碼加入，系統限制最多 8 人。
+3. 房主可選擇題目或使用隨機播放開始一回合，歌曲會透過嵌入的 YouTube 播放。
+4. 玩家在 2 分鐘內輸入動畫名稱作答，第一個達到 80% 相似度者得 1 分。
+5. 若所有玩家都按下「跳過」，系統會自動換到下一首並不計分。
+6. 達到預設或自訂的目標分數後，該局結束並顯示排行榜。
+
+---
+
+## 6. 題庫與後台管理
+
+1. 只有持有 `ADMIN_TOKEN` 的使用者可以進入後台審核頁面，記得保管好這個值。
+2. 在後台可以新增歌曲（輸入 YouTube 連結或影片 ID）、標記動畫名稱，並檢視待審核列表。
+3. 審核通過後，歌曲才會加入正式題庫，供房主在遊戲中選用。
+
+---
+
+## 7. 結束服務與清理
+
+1. 要停止後端時，在啟動伺服器的終端機按下 `Ctrl + C`。
+2. 停止前端開發伺服器，也按 `Ctrl + C`。
+3. 若要離開虛擬環境，在終端機輸入 `deactivate`。
+
+---
+
+## 8. 延伸閱讀與 API 節錄
+
+- `POST /rooms`：建立房間並回傳房主的玩家資訊。
+- `POST /rooms/{code}/join`：以暱稱加入指定房間。
+- `POST /rooms/{code}/start_round`：開始下一題，可選擇指定歌曲。
+- `POST /rooms/{code}/rounds/{round_id}/guess`：提交玩家猜測，伺服器回傳相似度與是否結束該題。
+- `POST /rooms/{code}/rounds/{round_id}/skip`：送出跳過投票，全員同意後直接跳題。
+- `GET /rooms/{code}/rounds/current`：取得目前正在播放的歌曲資訊（若題目已結束會自動顯示答案）。
+- `POST /admin/songs` / `POST /admin/songs/{id}/approve` / `POST /admin/songs/{id}/reject`：題庫新增與審核（需附帶 `X-Admin-Token`）。
+
+希望這份逐步指南能協助你順利啟動並體驗遊戲，若有更多需求可再進一步擴充功能與界面。

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ source .venv/bin/activate  # Windows 使用 .venv\Scripts\activate
 
    終端機出現 `Uvicorn running on http://0.0.0.0:8000`（或顯示實際區網 IP）代表後端啟動成功，其他裝置才能順利連線。
 
+   > 若之後想限制只能從特定網址呼叫 API，可設定環境變數 `CORS_ALLOW_ORIGINS`（以逗號分隔，例如 `http://localhost:5173,http://127.0.0.1:5173`）。
+
 5. 測試健康檢查：在另一個終端機或瀏覽器開啟 `http://localhost:8000/health`，應會看到 `{"status":"ok"}`。
 
 ---

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,51 @@
+"""Database configuration and session management for the anime quiz backend."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlmodel import SQLModel, Session, create_engine
+
+_DEFAULT_SQLITE_URL = "sqlite:///./anime_quiz.db"
+
+
+def _build_engine() -> tuple[str, dict[str, object]]:
+    database_url = os.getenv("DATABASE_URL", _DEFAULT_SQLITE_URL)
+    connect_args: dict[str, object] = {}
+    if database_url.startswith("sqlite"):  # enable SQLite usage in multi-threaded FastAPI
+        connect_args = {"check_same_thread": False}
+    return database_url, connect_args
+
+
+DATABASE_URL, _CONNECT_ARGS = _build_engine()
+engine = create_engine(DATABASE_URL, echo=False, connect_args=_CONNECT_ARGS)
+
+
+def init_db() -> None:
+    """Create database tables if they do not exist."""
+
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Generator[Session, None, None]:
+    """FastAPI dependency that provides a database session."""
+
+    with Session(engine) as session:
+        yield session
+
+
+@contextmanager
+def session_scope() -> Generator[Session, None, None]:
+    """Context manager for manual session usage outside of dependencies."""
+
+    session = Session(engine)
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -116,7 +116,7 @@ def _build_room_state(session: Session, room: Room) -> RoomState:
         created_at=room.created_at,
         updated_at=room.updated_at,
         winning_player_id=room.winning_player_id,
-        players=[PlayerRead.from_orm(player) for player in players],
+        players=[PlayerRead.model_validate(player, from_attributes=True) for player in players],
     )
 
 
@@ -190,7 +190,7 @@ def create_song(
     session.add(song)
     session.commit()
     session.refresh(song)
-    return SongRead.from_orm(song)
+    return SongRead.model_validate(song, from_attributes=True)
 
 
 @app.get("/songs", response_model=list[SongRead])
@@ -202,7 +202,7 @@ def list_songs(
     if status_filter:
         statement = statement.where(Song.status == status_filter)
     songs = session.exec(statement.order_by(Song.title)).all()
-    return [SongRead.from_orm(song) for song in songs]
+    return [SongRead.model_validate(song, from_attributes=True) for song in songs]
 
 
 @app.patch("/admin/songs/{song_id}", response_model=SongRead)
@@ -216,7 +216,7 @@ def update_song(
     if not song:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Song not found")
 
-    update_data = song_update.dict(exclude_unset=True)
+    update_data = song_update.model_dump(exclude_unset=True)
     if "youtube_url" in update_data:
         youtube_id = extract_youtube_id(update_data["youtube_url"])
         update_data["youtube_video_id"] = youtube_id
@@ -226,7 +226,7 @@ def update_song(
     session.add(song)
     session.commit()
     session.refresh(song)
-    return SongRead.from_orm(song)
+    return SongRead.model_validate(song, from_attributes=True)
 
 
 @app.post("/admin/songs/{song_id}/approve", response_model=SongRead)
@@ -243,7 +243,7 @@ def approve_song(
     session.add(song)
     session.commit()
     session.refresh(song)
-    return SongRead.from_orm(song)
+    return SongRead.model_validate(song, from_attributes=True)
 
 
 @app.post("/admin/songs/{song_id}/reject", response_model=SongRead)
@@ -260,7 +260,7 @@ def reject_song(
     session.add(song)
     session.commit()
     session.refresh(song)
-    return SongRead.from_orm(song)
+    return SongRead.model_validate(song, from_attributes=True)
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +297,7 @@ def create_room(room_in: RoomCreate, session: Session = Depends(get_session)) ->
 
     return RoomJoinResponse(
         room=_build_room_state(session, room),
-        player=PlayerRead.from_orm(host_player),
+        player=PlayerRead.model_validate(host_player, from_attributes=True),
     )
 
 
@@ -331,7 +331,7 @@ def join_room(code: str, join_request: JoinRoomRequest, session: Session = Depen
 
     return RoomJoinResponse(
         room=_build_room_state(session, room),
-        player=PlayerRead.from_orm(player),
+        player=PlayerRead.model_validate(player, from_attributes=True),
     )
 
 
@@ -460,7 +460,7 @@ def submit_guess(
     session.refresh(room)
 
     return GuessResponse(
-        guess=GuessRead.from_orm(guess),
+        guess=GuessRead.model_validate(guess, from_attributes=True),
         is_correct=is_correct,
         similarity=similarity,
         round_status=round_obj.status,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,552 @@
+"""FastAPI application that powers the anime music quiz platform."""
+
+from __future__ import annotations
+
+import os
+import random
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, status
+from fastapi.middleware.cors import CORSMiddleware
+from sqlmodel import Session, func, select
+
+from .database import get_session, init_db
+from .models import Guess, Player, Room, Round, SkipVote, Song
+from .schemas import (
+    GuessCreate,
+    GuessRead,
+    GuessResponse,
+    JoinRoomRequest,
+    LeaderboardEntry,
+    LeaderboardResponse,
+    PlayerRead,
+    RoomCreate,
+    RoomJoinResponse,
+    RoomState,
+    RoundStartRequest,
+    RoundState,
+    SkipRequest,
+    SkipResponse,
+    SongCreate,
+    SongPlaybackInfo,
+    SongRead,
+    SongUpdate,
+)
+from .utils import compute_similarity, extract_youtube_id
+
+
+ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "changeme")
+DEFAULT_ALLOWED_ORIGINS = {"http://localhost:5173", "http://127.0.0.1:5173", "http://localhost:4173"}
+
+
+app = FastAPI(title="Anime Music Quiz API", version="0.1.0")
+
+
+@app.on_event("startup")
+def startup() -> None:
+    init_db()
+
+
+cors_origins = os.getenv("CORS_ALLOW_ORIGINS")
+allow_origins = DEFAULT_ALLOWED_ORIGINS if not cors_origins else {origin.strip() for origin in cors_origins.split(",") if origin.strip()}
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=list(allow_origins) or ["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"]
+)
+
+
+@app.get("/health")
+async def read_health() -> dict[str, str]:
+    """Health check endpoint returning a simple status payload."""
+
+    return {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Dependencies & helpers
+# ---------------------------------------------------------------------------
+
+
+def require_admin_token(x_admin_token: str = Header(..., alias="X-Admin-Token")) -> str:
+    expected_token = ADMIN_TOKEN
+    if not expected_token:
+        return x_admin_token
+    if x_admin_token != expected_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid admin token")
+    return x_admin_token
+
+
+def _generate_room_code(session: Session, length: int = 5) -> str:
+    alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+    while True:
+        code = "".join(random.choice(alphabet) for _ in range(length))
+        existing = session.exec(select(Room).where(Room.code == code)).first()
+        if not existing:
+            return code
+
+
+def _get_room_or_404(session: Session, code: str) -> Room:
+    room = session.exec(select(Room).where(Room.code == code.upper())).first()
+    if not room:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found")
+    return room
+
+
+def _get_active_round(session: Session, room_id: int) -> Optional[Round]:
+    return session.exec(
+        select(Round).where(Round.room_id == room_id, Round.status == "playing").order_by(Round.started_at.desc())
+    ).first()
+
+
+def _build_room_state(session: Session, room: Room) -> RoomState:
+    players = session.exec(select(Player).where(Player.room_id == room.id).order_by(Player.joined_at)).all()
+    return RoomState(
+        id=room.id,
+        code=room.code,
+        status=room.status,
+        target_score=room.target_score,
+        max_players=room.max_players,
+        round_duration_seconds=room.round_duration_seconds,
+        host_name=room.host_name,
+        created_at=room.created_at,
+        updated_at=room.updated_at,
+        winning_player_id=room.winning_player_id,
+        players=[PlayerRead.model_validate(player) for player in players],
+    )
+
+
+def _build_round_state(
+    session: Session,
+    round_obj: Round,
+    room: Optional[Room] = None,
+    *,
+    reveal_answer: bool = False,
+) -> RoundState:
+    room = room or session.get(Room, round_obj.room_id)
+    if room is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Room not found")
+    song = session.get(Song, round_obj.song_id)
+    if song is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Song not found")
+
+    skip_votes_count = session.exec(
+        select(func.count()).select_from(SkipVote).where(SkipVote.round_id == round_obj.id)
+    ).scalar() or 0
+    player_count = session.exec(
+        select(func.count()).select_from(Player).where(Player.room_id == room.id)
+    ).scalar() or 0
+
+    reveal_solution = reveal_answer or round_obj.status != "playing"
+
+    playback = SongPlaybackInfo(
+        id=song.id,
+        title=song.title,
+        youtube_url=song.youtube_url,
+        youtube_video_id=song.youtube_video_id,
+        start_time_seconds=song.start_time_seconds,
+        anime_title=song.anime_title if reveal_solution else None,
+    )
+
+    return RoundState(
+        id=round_obj.id,
+        room_code=room.code,
+        status=round_obj.status,
+        duration_seconds=round_obj.duration_seconds,
+        started_at=round_obj.started_at,
+        ends_at=round_obj.started_at + timedelta(seconds=round_obj.duration_seconds),
+        winning_player_id=round_obj.winning_player_id,
+        song=playback,
+        skip_votes=int(skip_votes_count or 0),
+        total_players=int(player_count or 0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Song management (admin)
+# ---------------------------------------------------------------------------
+
+
+@app.post("/admin/songs", response_model=SongRead, status_code=status.HTTP_201_CREATED)
+def create_song(
+    song_in: SongCreate,
+    session: Session = Depends(get_session),
+    _: str = Depends(require_admin_token),
+) -> SongRead:
+    youtube_id = extract_youtube_id(song_in.youtube_url)
+    song = Song(
+        title=song_in.title.strip(),
+        anime_title=song_in.anime_title.strip(),
+        youtube_url=song_in.youtube_url.strip(),
+        youtube_video_id=youtube_id,
+        start_time_seconds=song_in.start_time_seconds,
+        notes=song_in.notes,
+        status=song_in.status or "pending",
+    )
+    session.add(song)
+    session.commit()
+    session.refresh(song)
+    return SongRead.model_validate(song)
+
+
+@app.get("/songs", response_model=list[SongRead])
+def list_songs(
+    status_filter: Optional[str] = Query(default="approved", alias="status"),
+    session: Session = Depends(get_session),
+) -> list[SongRead]:
+    statement = select(Song)
+    if status_filter:
+        statement = statement.where(Song.status == status_filter)
+    songs = session.exec(statement.order_by(Song.title)).all()
+    return [SongRead.model_validate(song) for song in songs]
+
+
+@app.patch("/admin/songs/{song_id}", response_model=SongRead)
+def update_song(
+    song_id: int,
+    song_update: SongUpdate,
+    session: Session = Depends(get_session),
+    _: str = Depends(require_admin_token),
+) -> SongRead:
+    song = session.get(Song, song_id)
+    if not song:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Song not found")
+
+    update_data = song_update.dict(exclude_unset=True)
+    if "youtube_url" in update_data:
+        youtube_id = extract_youtube_id(update_data["youtube_url"])
+        update_data["youtube_video_id"] = youtube_id
+    for field, value in update_data.items():
+        setattr(song, field, value)
+    song.updated_at = datetime.utcnow()
+    session.add(song)
+    session.commit()
+    session.refresh(song)
+    return SongRead.model_validate(song)
+
+
+@app.post("/admin/songs/{song_id}/approve", response_model=SongRead)
+def approve_song(
+    song_id: int,
+    session: Session = Depends(get_session),
+    _: str = Depends(require_admin_token),
+) -> SongRead:
+    song = session.get(Song, song_id)
+    if not song:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Song not found")
+    song.status = "approved"
+    song.updated_at = datetime.utcnow()
+    session.add(song)
+    session.commit()
+    session.refresh(song)
+    return SongRead.model_validate(song)
+
+
+@app.post("/admin/songs/{song_id}/reject", response_model=SongRead)
+def reject_song(
+    song_id: int,
+    session: Session = Depends(get_session),
+    _: str = Depends(require_admin_token),
+) -> SongRead:
+    song = session.get(Song, song_id)
+    if not song:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Song not found")
+    song.status = "rejected"
+    song.updated_at = datetime.utcnow()
+    session.add(song)
+    session.commit()
+    session.refresh(song)
+    return SongRead.model_validate(song)
+
+
+# ---------------------------------------------------------------------------
+# Room & player management
+# ---------------------------------------------------------------------------
+
+
+@app.post("/rooms", response_model=RoomJoinResponse, status_code=status.HTTP_201_CREATED)
+def create_room(room_in: RoomCreate, session: Session = Depends(get_session)) -> RoomJoinResponse:
+    code = (room_in.code or _generate_room_code(session)).upper()
+    existing = session.exec(select(Room).where(Room.code == code)).first()
+    if existing:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Room code already in use")
+
+    room = Room(
+        code=code,
+        host_name=room_in.host_name.strip(),
+        target_score=room_in.target_score,
+        max_players=min(room_in.max_players, 8),
+        round_duration_seconds=room_in.round_duration_seconds,
+        status="waiting",
+    )
+    session.add(room)
+    session.commit()
+    session.refresh(room)
+
+    host_player = Player(room_id=room.id, nickname=room.host_name, is_host=True)
+    session.add(host_player)
+    room.updated_at = datetime.utcnow()
+    session.add(room)
+    session.commit()
+    session.refresh(host_player)
+    session.refresh(room)
+
+    return RoomJoinResponse(
+        room=_build_room_state(session, room),
+        player=PlayerRead.model_validate(host_player),
+    )
+
+
+@app.get("/rooms/{code}", response_model=RoomState)
+def get_room(code: str, session: Session = Depends(get_session)) -> RoomState:
+    room = _get_room_or_404(session, code)
+    return _build_room_state(session, room)
+
+
+@app.post("/rooms/{code}/join", response_model=RoomJoinResponse)
+def join_room(code: str, join_request: JoinRoomRequest, session: Session = Depends(get_session)) -> RoomJoinResponse:
+    room = _get_room_or_404(session, code)
+    if room.status == "finished":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Room has already finished")
+
+    players = session.exec(select(Player).where(Player.room_id == room.id)).all()
+    if len(players) >= room.max_players:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Room is full")
+
+    normalized_nickname = join_request.nickname.strip()
+    if any(player.nickname.lower() == normalized_nickname.lower() for player in players):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nickname already taken")
+
+    player = Player(room_id=room.id, nickname=normalized_nickname)
+    session.add(player)
+    room.updated_at = datetime.utcnow()
+    session.add(room)
+    session.commit()
+    session.refresh(player)
+    session.refresh(room)
+
+    return RoomJoinResponse(
+        room=_build_room_state(session, room),
+        player=PlayerRead.model_validate(player),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rounds and guessing
+# ---------------------------------------------------------------------------
+
+
+@app.post("/rooms/{code}/start_round", response_model=RoundState)
+def start_round(
+    code: str,
+    payload: RoundStartRequest,
+    session: Session = Depends(get_session),
+) -> RoundState:
+    room = _get_room_or_404(session, code)
+    active_round = _get_active_round(session, room.id)
+    if active_round:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="A round is already in progress")
+
+    player_total = session.exec(
+        select(func.count()).select_from(Player).where(Player.room_id == room.id)
+    ).scalar() or 0
+    if player_total == 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No players in room")
+
+    song: Optional[Song]
+    if payload.song_id is not None:
+        song = session.get(Song, payload.song_id)
+        if not song or song.status != "approved":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Song is not available")
+    else:
+        all_songs = session.exec(select(Song).where(Song.status == "approved")).all()
+        if not all_songs:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No approved songs available")
+        used_song_ids = {
+            round_song_id
+            for round_song_id in session.exec(select(Round.song_id).where(Round.room_id == room.id)).all()
+        }
+        available = [song_item for song_item in all_songs if song_item.id not in used_song_ids]
+        song = random.choice(available or all_songs)
+
+    duration = payload.duration_seconds or room.round_duration_seconds
+    round_obj = Round(
+        room_id=room.id,
+        song_id=song.id,
+        duration_seconds=duration,
+        status="playing",
+    )
+    session.add(round_obj)
+    room.status = "in_progress"
+    room.updated_at = datetime.utcnow()
+    session.add(room)
+    session.commit()
+    session.refresh(round_obj)
+    session.refresh(room)
+
+    return _build_round_state(session, round_obj, room=room, reveal_answer=payload.reveal_answer)
+
+
+@app.get("/rooms/{code}/rounds/current", response_model=RoundState)
+def get_current_round(
+    code: str,
+    reveal_answer: bool = Query(default=False),
+    session: Session = Depends(get_session),
+) -> RoundState:
+    room = _get_room_or_404(session, code)
+    round_obj = _get_active_round(session, room.id)
+    if not round_obj:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No active round")
+    return _build_round_state(session, round_obj, room=room, reveal_answer=reveal_answer)
+
+
+@app.post("/rooms/{code}/rounds/{round_id}/guess", response_model=GuessResponse)
+def submit_guess(
+    code: str,
+    round_id: int,
+    guess_in: GuessCreate,
+    session: Session = Depends(get_session),
+) -> GuessResponse:
+    room = _get_room_or_404(session, code)
+    round_obj = session.get(Round, round_id)
+    if not round_obj or round_obj.room_id != room.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Round not found")
+    if round_obj.status != "playing":
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Round is not accepting guesses")
+
+    player = session.get(Player, guess_in.player_id)
+    if not player or player.room_id != room.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Player not found in this room")
+
+    song = session.get(Song, round_obj.song_id)
+    if not song:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Song not found")
+
+    similarity = compute_similarity(song.anime_title, guess_in.guess_text)
+    is_correct = similarity >= 0.8
+
+    guess = Guess(
+        round_id=round_obj.id,
+        player_id=player.id,
+        guess_text=guess_in.guess_text.strip(),
+        similarity=similarity,
+        is_correct=is_correct,
+    )
+    session.add(guess)
+
+    if is_correct and round_obj.winning_player_id is None:
+        round_obj.status = "completed"
+        round_obj.winning_player_id = player.id
+        round_obj.ended_at = datetime.utcnow()
+        player.score += 1
+        room.updated_at = datetime.utcnow()
+        if player.score >= room.target_score:
+            room.status = "finished"
+            room.winning_player_id = player.id
+        else:
+            room.status = "waiting"
+        session.add(round_obj)
+        session.add(player)
+        session.add(room)
+
+    session.commit()
+    session.refresh(guess)
+    session.refresh(player)
+    session.refresh(round_obj)
+    session.refresh(room)
+
+    return GuessResponse(
+        guess=GuessRead.model_validate(guess),
+        is_correct=is_correct,
+        similarity=similarity,
+        round_status=round_obj.status,
+        player_score=player.score,
+        room_status=room.status,
+        target_score=room.target_score,
+        winning_player_id=round_obj.winning_player_id,
+    )
+
+
+@app.post("/rooms/{code}/rounds/{round_id}/skip", response_model=SkipResponse)
+def skip_round(
+    code: str,
+    round_id: int,
+    request: SkipRequest,
+    session: Session = Depends(get_session),
+) -> SkipResponse:
+    room = _get_room_or_404(session, code)
+    round_obj = session.get(Round, round_id)
+    if not round_obj or round_obj.room_id != room.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Round not found")
+
+    player = session.get(Player, request.player_id)
+    if not player or player.room_id != room.id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Player not found in this room")
+
+    if round_obj.status != "playing":
+        skip_votes = session.exec(
+            select(func.count()).select_from(SkipVote).where(SkipVote.round_id == round_obj.id)
+        ).scalar() or 0
+        total_players = session.exec(
+            select(func.count()).select_from(Player).where(Player.room_id == room.id)
+        ).scalar() or 0
+        return SkipResponse(
+            skip_votes=int(skip_votes),
+            total_players=int(total_players),
+            round_status=round_obj.status,
+        )
+
+    existing_vote = session.exec(
+        select(SkipVote).where(SkipVote.round_id == round_obj.id, SkipVote.player_id == player.id)
+    ).first()
+    if not existing_vote:
+        session.add(SkipVote(round_id=round_obj.id, player_id=player.id))
+        session.commit()
+
+    skip_votes_count = session.exec(
+        select(func.count()).select_from(SkipVote).where(SkipVote.round_id == round_obj.id)
+    ).scalar() or 0
+    total_players = session.exec(
+        select(func.count()).select_from(Player).where(Player.room_id == room.id)
+    ).scalar() or 0
+
+    if skip_votes_count >= total_players and round_obj.status == "playing":
+        round_obj.status = "skipped"
+        round_obj.ended_at = datetime.utcnow()
+        room.status = "waiting"
+        room.updated_at = datetime.utcnow()
+        session.add(round_obj)
+        session.add(room)
+        session.commit()
+        session.refresh(round_obj)
+        session.refresh(room)
+
+    return SkipResponse(
+        skip_votes=int(skip_votes_count),
+        total_players=int(total_players),
+        round_status=round_obj.status,
+    )
+
+
+@app.get("/rooms/{code}/leaderboard", response_model=LeaderboardResponse)
+def get_leaderboard(code: str, session: Session = Depends(get_session)) -> LeaderboardResponse:
+    room = _get_room_or_404(session, code)
+    players = session.exec(
+        select(Player).where(Player.room_id == room.id).order_by(Player.score.desc(), Player.joined_at)
+    ).all()
+    return LeaderboardResponse(
+        room_code=room.code,
+        players=[
+            LeaderboardEntry(
+                player_id=player.id,
+                nickname=player.nickname,
+                score=player.score,
+                is_host=player.is_host,
+            )
+            for player in players
+        ],
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -116,7 +116,7 @@ def _build_room_state(session: Session, room: Room) -> RoomState:
         created_at=room.created_at,
         updated_at=room.updated_at,
         winning_player_id=room.winning_player_id,
-        players=[PlayerRead.model_validate(player) for player in players],
+        players=[PlayerRead.from_orm(player) for player in players],
     )
 
 
@@ -190,7 +190,7 @@ def create_song(
     session.add(song)
     session.commit()
     session.refresh(song)
-    return SongRead.model_validate(song)
+    return SongRead.from_orm(song)
 
 
 @app.get("/songs", response_model=list[SongRead])
@@ -202,7 +202,7 @@ def list_songs(
     if status_filter:
         statement = statement.where(Song.status == status_filter)
     songs = session.exec(statement.order_by(Song.title)).all()
-    return [SongRead.model_validate(song) for song in songs]
+    return [SongRead.from_orm(song) for song in songs]
 
 
 @app.patch("/admin/songs/{song_id}", response_model=SongRead)
@@ -226,7 +226,7 @@ def update_song(
     session.add(song)
     session.commit()
     session.refresh(song)
-    return SongRead.model_validate(song)
+    return SongRead.from_orm(song)
 
 
 @app.post("/admin/songs/{song_id}/approve", response_model=SongRead)
@@ -243,7 +243,7 @@ def approve_song(
     session.add(song)
     session.commit()
     session.refresh(song)
-    return SongRead.model_validate(song)
+    return SongRead.from_orm(song)
 
 
 @app.post("/admin/songs/{song_id}/reject", response_model=SongRead)
@@ -260,7 +260,7 @@ def reject_song(
     session.add(song)
     session.commit()
     session.refresh(song)
-    return SongRead.model_validate(song)
+    return SongRead.from_orm(song)
 
 
 # ---------------------------------------------------------------------------
@@ -297,7 +297,7 @@ def create_room(room_in: RoomCreate, session: Session = Depends(get_session)) ->
 
     return RoomJoinResponse(
         room=_build_room_state(session, room),
-        player=PlayerRead.model_validate(host_player),
+        player=PlayerRead.from_orm(host_player),
     )
 
 
@@ -331,7 +331,7 @@ def join_room(code: str, join_request: JoinRoomRequest, session: Session = Depen
 
     return RoomJoinResponse(
         room=_build_room_state(session, room),
-        player=PlayerRead.model_validate(player),
+        player=PlayerRead.from_orm(player),
     )
 
 
@@ -460,7 +460,7 @@ def submit_guess(
     session.refresh(room)
 
     return GuessResponse(
-        guess=GuessRead.model_validate(guess),
+        guess=GuessRead.from_orm(guess),
         is_correct=is_correct,
         similarity=similarity,
         round_status=round_obj.status,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,12 +49,24 @@ def startup() -> None:
 
 
 cors_origins = os.getenv("CORS_ALLOW_ORIGINS")
-allow_origins = DEFAULT_ALLOWED_ORIGINS if not cors_origins else {origin.strip() for origin in cors_origins.split(",") if origin.strip()}
+if cors_origins:
+    allow_origins = {
+        origin.strip()
+        for origin in cors_origins.split(",")
+        if origin.strip()
+    }
+    if not allow_origins:
+        allow_origins = set(DEFAULT_ALLOWED_ORIGINS)
+    allow_all_origins = False
+else:
+    # 預設允許所有來源，方便玩家透過主機的區網 IP 連線。
+    allow_origins = {"*"}
+    allow_all_origins = True
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=list(allow_origins) or ["*"],
-    allow_credentials=True,
+    allow_origins=list(allow_origins),
+    allow_credentials=not allow_all_origins,
     allow_methods=["*"],
     allow_headers=["*"]
 )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,97 @@
+"""Database models for the anime music quiz application."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel, UniqueConstraint
+
+
+class Song(SQLModel, table=True):
+    """Song information sourced from YouTube or manual input."""
+
+    __tablename__ = "songs"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str = Field(nullable=False, index=True)
+    anime_title: str = Field(nullable=False, index=True)
+    youtube_url: str = Field(nullable=False)
+    youtube_video_id: str = Field(nullable=False, index=True)
+    start_time_seconds: int = Field(default=0, ge=0)
+    status: str = Field(default="pending", index=True)
+    notes: Optional[str] = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class Room(SQLModel, table=True):
+    """Represents a quiz room that players can join via a code."""
+
+    __tablename__ = "rooms"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    code: str = Field(nullable=False, unique=True, index=True)
+    host_name: str = Field(nullable=False)
+    target_score: int = Field(default=5, ge=1)
+    max_players: int = Field(default=8, ge=1)
+    round_duration_seconds: int = Field(default=120, ge=10)
+    status: str = Field(default="waiting", index=True)
+    winning_player_id: Optional[int] = Field(default=None, foreign_key="players.id")
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    updated_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class Player(SQLModel, table=True):
+    """Player participating in a room."""
+
+    __tablename__ = "players"
+    __table_args__ = (UniqueConstraint("room_id", "nickname", name="uq_room_nickname"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    room_id: int = Field(foreign_key="rooms.id", nullable=False, index=True)
+    nickname: str = Field(nullable=False)
+    score: int = Field(default=0, ge=0)
+    is_host: bool = Field(default=False)
+    joined_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class Round(SQLModel, table=True):
+    """Single round where one song is played and players guess."""
+
+    __tablename__ = "rounds"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    room_id: int = Field(foreign_key="rooms.id", nullable=False, index=True)
+    song_id: int = Field(foreign_key="songs.id", nullable=False)
+    status: str = Field(default="playing", index=True)
+    started_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+    ended_at: Optional[datetime] = Field(default=None)
+    duration_seconds: int = Field(default=120, ge=10)
+    winning_player_id: Optional[int] = Field(default=None, foreign_key="players.id")
+
+
+class Guess(SQLModel, table=True):
+    """Stores guesses players make during a round."""
+
+    __tablename__ = "guesses"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    round_id: int = Field(foreign_key="rounds.id", nullable=False, index=True)
+    player_id: int = Field(foreign_key="players.id", nullable=False, index=True)
+    guess_text: str = Field(nullable=False)
+    similarity: float = Field(default=0.0, ge=0.0, le=1.0)
+    is_correct: bool = Field(default=False)
+    submitted_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)
+
+
+class SkipVote(SQLModel, table=True):
+    """Tracks players that voted to skip the current song."""
+
+    __tablename__ = "skip_votes"
+    __table_args__ = (UniqueConstraint("round_id", "player_id", name="uq_round_skip"),)
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    round_id: int = Field(foreign_key="rounds.id", nullable=False, index=True)
+    player_id: int = Field(foreign_key="players.id", nullable=False, index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,183 @@
+"""Pydantic schemas used by the API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class SongCreate(BaseModel):
+    title: str
+    anime_title: str = Field(description="Expected answer when players guess the anime title.")
+    youtube_url: str
+    start_time_seconds: int = Field(default=0, ge=0)
+    notes: Optional[str] = None
+    status: Optional[str] = Field(default="pending")
+
+    @field_validator("status")
+    def validate_status(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        allowed = {"pending", "approved", "rejected"}
+        if value not in allowed:
+            raise ValueError(f"status must be one of {sorted(allowed)}")
+        return value
+
+
+class SongUpdate(BaseModel):
+    title: Optional[str] = None
+    anime_title: Optional[str] = None
+    youtube_url: Optional[str] = None
+    start_time_seconds: Optional[int] = Field(default=None, ge=0)
+    notes: Optional[str] = None
+    status: Optional[str] = None
+
+    @field_validator("status")
+    def validate_status(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return value
+        allowed = {"pending", "approved", "rejected"}
+        if value not in allowed:
+            raise ValueError(f"status must be one of {sorted(allowed)}")
+        return value
+
+
+class SongRead(BaseModel):
+    id: int
+    title: str
+    anime_title: str
+    youtube_url: str
+    youtube_video_id: str
+    start_time_seconds: int
+    status: str
+    notes: Optional[str]
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SongPlaybackInfo(BaseModel):
+    id: int
+    title: str
+    youtube_url: str
+    youtube_video_id: str
+    start_time_seconds: int
+    anime_title: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RoomCreate(BaseModel):
+    host_name: str = Field(description="Name of the room host (will become the first player).")
+    code: Optional[str] = Field(default=None, min_length=3, max_length=12)
+    target_score: int = Field(default=5, ge=1)
+    max_players: int = Field(default=8, ge=1)
+    round_duration_seconds: int = Field(default=120, ge=10)
+
+
+class PlayerRead(BaseModel):
+    id: int
+    nickname: str
+    score: int
+    is_host: bool
+    joined_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RoomState(BaseModel):
+    id: int
+    code: str
+    status: str
+    target_score: int
+    max_players: int
+    round_duration_seconds: int
+    host_name: str
+    created_at: datetime
+    updated_at: datetime
+    winning_player_id: Optional[int] = None
+    players: List[PlayerRead]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RoomJoinResponse(BaseModel):
+    room: RoomState
+    player: PlayerRead
+
+
+class JoinRoomRequest(BaseModel):
+    nickname: str = Field(min_length=1, max_length=32)
+
+
+class RoundStartRequest(BaseModel):
+    song_id: Optional[int] = None
+    duration_seconds: Optional[int] = Field(default=None, ge=10)
+    reveal_answer: bool = False
+
+
+class RoundState(BaseModel):
+    id: int
+    room_code: str
+    status: str
+    duration_seconds: int
+    started_at: datetime
+    ends_at: datetime
+    winning_player_id: Optional[int]
+    song: SongPlaybackInfo
+    skip_votes: int
+    total_players: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GuessCreate(BaseModel):
+    player_id: int
+    guess_text: str = Field(min_length=1, max_length=200)
+
+
+class GuessRead(BaseModel):
+    id: int
+    player_id: int
+    guess_text: str
+    similarity: float
+    is_correct: bool
+    submitted_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class GuessResponse(BaseModel):
+    guess: GuessRead
+    is_correct: bool
+    similarity: float
+    round_status: str
+    player_score: int
+    room_status: str
+    target_score: int
+    winning_player_id: Optional[int] = None
+
+
+class SkipRequest(BaseModel):
+    player_id: int
+
+
+class SkipResponse(BaseModel):
+    skip_votes: int
+    total_players: int
+    round_status: str
+
+
+class LeaderboardEntry(BaseModel):
+    player_id: int
+    nickname: str
+    score: int
+    is_host: bool
+
+
+class LeaderboardResponse(BaseModel):
+    room_code: str
+    players: List[LeaderboardEntry]

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SongCreate(BaseModel):
@@ -16,7 +16,8 @@ class SongCreate(BaseModel):
     notes: Optional[str] = None
     status: Optional[str] = Field(default="pending")
 
-    @validator("status")
+    @field_validator("status")
+    @classmethod
     def validate_status(cls, value: Optional[str]) -> Optional[str]:
         if value is None:
             return value
@@ -34,7 +35,8 @@ class SongUpdate(BaseModel):
     notes: Optional[str] = None
     status: Optional[str] = None
 
-    @validator("status")
+    @field_validator("status")
+    @classmethod
     def validate_status(cls, value: Optional[str]) -> Optional[str]:
         if value is None:
             return value
@@ -45,6 +47,8 @@ class SongUpdate(BaseModel):
 
 
 class SongRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     title: str
     anime_title: str
@@ -56,20 +60,16 @@ class SongRead(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    class Config:
-        orm_mode = True
-
 
 class SongPlaybackInfo(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     title: str
     youtube_url: str
     youtube_video_id: str
     start_time_seconds: int
     anime_title: Optional[str] = None
-
-    class Config:
-        orm_mode = True
 
 
 class RoomCreate(BaseModel):
@@ -81,17 +81,18 @@ class RoomCreate(BaseModel):
 
 
 class PlayerRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     nickname: str
     score: int
     is_host: bool
     joined_at: datetime
 
-    class Config:
-        orm_mode = True
-
 
 class RoomState(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     code: str
     status: str
@@ -103,9 +104,6 @@ class RoomState(BaseModel):
     updated_at: datetime
     winning_player_id: Optional[int] = None
     players: List[PlayerRead]
-
-    class Config:
-        orm_mode = True
 
 
 class RoomJoinResponse(BaseModel):
@@ -124,6 +122,8 @@ class RoundStartRequest(BaseModel):
 
 
 class RoundState(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     room_code: str
     status: str
@@ -135,9 +135,6 @@ class RoundState(BaseModel):
     skip_votes: int
     total_players: int
 
-    class Config:
-        orm_mode = True
-
 
 class GuessCreate(BaseModel):
     player_id: int
@@ -145,15 +142,14 @@ class GuessCreate(BaseModel):
 
 
 class GuessRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     id: int
     player_id: int
     guess_text: str
     similarity: float
     is_correct: bool
     submitted_at: datetime
-
-    class Config:
-        orm_mode = True
 
 
 class GuessResponse(BaseModel):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, Field, validator
 
 
 class SongCreate(BaseModel):
@@ -16,7 +16,7 @@ class SongCreate(BaseModel):
     notes: Optional[str] = None
     status: Optional[str] = Field(default="pending")
 
-    @field_validator("status")
+    @validator("status")
     def validate_status(cls, value: Optional[str]) -> Optional[str]:
         if value is None:
             return value
@@ -34,7 +34,7 @@ class SongUpdate(BaseModel):
     notes: Optional[str] = None
     status: Optional[str] = None
 
-    @field_validator("status")
+    @validator("status")
     def validate_status(cls, value: Optional[str]) -> Optional[str]:
         if value is None:
             return value
@@ -56,7 +56,8 @@ class SongRead(BaseModel):
     created_at: datetime
     updated_at: datetime
 
-    model_config = ConfigDict(from_attributes=True)
+    class Config:
+        orm_mode = True
 
 
 class SongPlaybackInfo(BaseModel):
@@ -67,7 +68,8 @@ class SongPlaybackInfo(BaseModel):
     start_time_seconds: int
     anime_title: Optional[str] = None
 
-    model_config = ConfigDict(from_attributes=True)
+    class Config:
+        orm_mode = True
 
 
 class RoomCreate(BaseModel):
@@ -85,7 +87,8 @@ class PlayerRead(BaseModel):
     is_host: bool
     joined_at: datetime
 
-    model_config = ConfigDict(from_attributes=True)
+    class Config:
+        orm_mode = True
 
 
 class RoomState(BaseModel):
@@ -101,7 +104,8 @@ class RoomState(BaseModel):
     winning_player_id: Optional[int] = None
     players: List[PlayerRead]
 
-    model_config = ConfigDict(from_attributes=True)
+    class Config:
+        orm_mode = True
 
 
 class RoomJoinResponse(BaseModel):
@@ -131,7 +135,8 @@ class RoundState(BaseModel):
     skip_votes: int
     total_players: int
 
-    model_config = ConfigDict(from_attributes=True)
+    class Config:
+        orm_mode = True
 
 
 class GuessCreate(BaseModel):
@@ -147,7 +152,8 @@ class GuessRead(BaseModel):
     is_correct: bool
     submitted_at: datetime
 
-    model_config = ConfigDict(from_attributes=True)
+    class Config:
+        orm_mode = True
 
 
 class GuessResponse(BaseModel):

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -1,0 +1,52 @@
+"""Utility helpers for the anime quiz backend."""
+
+from __future__ import annotations
+
+import re
+from difflib import SequenceMatcher
+from urllib.parse import parse_qs, urlparse
+
+
+_YOUTUBE_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+
+def extract_youtube_id(value: str) -> str:
+    """Extract the YouTube video ID from a URL or return it if already provided."""
+
+    value = value.strip()
+    if _YOUTUBE_ID_PATTERN.fullmatch(value):
+        return value
+
+    parsed = urlparse(value)
+    if parsed.netloc.endswith("youtu.be"):
+        candidate = parsed.path.lstrip("/")
+        if _YOUTUBE_ID_PATTERN.fullmatch(candidate):
+            return candidate
+    if parsed.netloc.endswith("youtube.com"):
+        if parsed.path == "/watch":
+            query = parse_qs(parsed.query)
+            video_ids = query.get("v")
+            if video_ids:
+                candidate = video_ids[0]
+                if _YOUTUBE_ID_PATTERN.fullmatch(candidate):
+                    return candidate
+        if parsed.path.startswith("/embed/"):
+            candidate = parsed.path.split("/")[-1]
+            if _YOUTUBE_ID_PATTERN.fullmatch(candidate):
+                return candidate
+
+    raise ValueError("Unable to determine YouTube video ID from provided value")
+
+
+def compute_similarity(answer: str, guess: str) -> float:
+    """Return a similarity ratio between 0 and 1 for two strings."""
+
+    normalized_answer = _normalize_string(answer)
+    normalized_guess = _normalize_string(guess)
+    if not normalized_answer or not normalized_guess:
+        return 0.0
+    return SequenceMatcher(None, normalized_answer, normalized_guess).ratio()
+
+
+def _normalize_string(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().lower()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+sqlmodel==0.0.14

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.vscode/
+.DS_Store

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,39 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import react from 'eslint-plugin-react'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+
+export default [
+  {
+    ignores: ['dist'],
+  },
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      react,
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...react.configs.recommended.rules,
+      ...react.configs['jsx-runtime'].rules,
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+    },
+  },
+]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Anime Quiz App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.47",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "globals": "^13.24.0",
+    "vite": "^5.1.0"
+  }
+}

--- a/frontend/public/vite.svg
+++ b/frontend/public/vite.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--logos" width="31.88" height="32" preserveAspectRatio="xMidYMid meet" viewBox="0 0 256 257">
+  <defs>
+    <linearGradient id="IconifyId1813088fe1fbc01fb466" x1="-.828%" x2="57.636%" y1="7.652%" y2="78.411%">
+      <stop offset="0%" stop-color="#41D1FF"></stop>
+      <stop offset="100%" stop-color="#BD34FE"></stop>
+    </linearGradient>
+    <linearGradient id="IconifyId1813088fe1fbc01fb467" x1="43.376%" x2="50.316%" y1="2.242%" y2="89.03%">
+      <stop offset="0%" stop-color="#FFEA83"></stop>
+      <stop offset="8.333%" stop-color="#FFDD35"></stop>
+      <stop offset="100%" stop-color="#FFA800"></stop>
+    </linearGradient>
+  </defs>
+  <path fill="url(#IconifyId1813088fe1fbc01fb466)" d="M255.153 37.938L134.897 252.976c-2.483 4.44-8.862 4.466-11.382.048L.875 37.958c-2.746-4.814 1.371-10.646 6.827-9.67l120.385 21.517a6.537 6.537 0 0 0 2.322-.004l117.867-21.483c5.438-.991 9.574 4.796 6.877 9.62Z"></path>
+  <path fill="url(#IconifyId1813088fe1fbc01fb467)" d="M185.432.063L96.44 17.501a3.268 3.268 0 0 0-2.634 3.014l-5.474 92.456a3.268 3.268 0 0 0 3.997 3.378l24.777-5.718c2.318-.535 4.413 1.507 3.936 3.838l-7.361 36.047c-.495 2.426 1.782 4.5 4.151 3.78l15.304-4.649c2.372-.72 4.652 1.36 4.15 3.788l-11.698 56.621c-.732 3.542 3.979 5.473 5.943 2.437l1.313-2.028l72.516-144.72c1.215-2.423-.88-5.186-3.54-4.672l-25.505 4.922c-2.396.462-4.435-1.77-3.759-4.114l16.646-57.705c.677-2.35-1.37-4.583-3.769-4.113Z"></path>
+</svg>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,330 @@
+:root {
+  color-scheme: light;
+  font-family: 'Segoe UI', 'Noto Sans TC', system-ui, -apple-system, sans-serif;
+  background-color: #101322;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, #1f2241, #0c0f1e 60%);
+  color: #f7f9fc;
+}
+
+.app {
+  min-height: 100vh;
+  padding: 2rem clamp(1rem, 4vw, 3rem) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-title {
+  font-size: clamp(2.5rem, 6vw, 3.5rem);
+  margin-bottom: 0.25rem;
+}
+
+.app-subtitle {
+  margin-top: 0;
+  color: #cbd5ff;
+}
+
+.setup-container {
+  max-width: 960px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.setup-grid {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  background: rgba(30, 36, 74, 0.85);
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 60px rgba(15, 17, 36, 0.45);
+}
+
+.card h2,
+.card h3 {
+  margin-top: 0;
+  font-weight: 700;
+}
+
+.card label {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+}
+
+.card input,
+.card select,
+.card button {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 255, 0.3);
+  padding: 0.75rem;
+  font-size: 1rem;
+  background: rgba(17, 24, 39, 0.6);
+  color: #f8fafc;
+}
+
+.card button {
+  cursor: pointer;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  border: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.card button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(99, 102, 241, 0.35);
+}
+
+.card button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.secondary {
+  background: rgba(15, 23, 42, 0.6) !important;
+  border: 1px solid rgba(148, 163, 255, 0.35) !important;
+}
+
+.error-banner,
+.info-banner {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  font-size: 0.95rem;
+}
+
+.error-banner {
+  background: rgba(239, 68, 68, 0.15);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+}
+
+.info-banner {
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  color: #bfdbfe;
+}
+
+.dashboard {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.dashboard__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.dashboard__header h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.dashboard__header p {
+  margin: 0.2rem 0 0;
+  color: #cbd5ff;
+}
+
+.dashboard__host-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(99, 102, 241, 0.2);
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  color: #e0e7ff;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.badge--host {
+  background: rgba(250, 204, 21, 0.2);
+  border-color: rgba(250, 204, 21, 0.5);
+  color: #facc15;
+}
+
+.scoreboard ul,
+.admin-panel__lists ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.scoreboard li,
+.admin-panel__lists li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  background: rgba(17, 24, 39, 0.6);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 255, 0.15);
+}
+
+.scoreboard li.me {
+  border-color: rgba(251, 191, 36, 0.65);
+  box-shadow: inset 0 0 12px rgba(251, 191, 36, 0.35);
+}
+
+.scoreboard .score {
+  font-weight: 600;
+  color: #fbbf24;
+}
+
+.status-card {
+  text-align: center;
+  border-color: rgba(251, 191, 36, 0.4);
+  background: rgba(250, 204, 21, 0.15);
+}
+
+.host-controls__content {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-end;
+}
+
+.round-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #0f172a;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.answer-banner {
+  margin: 1rem 0 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(34, 197, 94, 0.18);
+  border: 1px solid rgba(34, 197, 94, 0.5);
+  color: #bbf7d0;
+}
+
+.guess-form {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.guess-form__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.round-complete {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  background: rgba(148, 163, 255, 0.15);
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 255, 0.35);
+}
+
+.app-footer {
+  text-align: right;
+  color: #94a3ff;
+  font-size: 0.85rem;
+}
+
+.app-footer code {
+  background: rgba(15, 23, 42, 0.6);
+  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+}
+
+.admin-panel__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-top: 1.5rem;
+}
+
+.admin-panel__form button {
+  margin-top: 0.5rem;
+}
+
+.admin-panel__list-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.admin-panel__list-actions .secondary {
+  color: #cbd5ff;
+}
+
+.muted {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.checkbox {
+  flex-direction: row !important;
+  align-items: center;
+  gap: 0.5rem !important;
+}
+
+.checkbox input {
+  width: auto;
+  accent-color: #6366f1;
+}
+
+@media (max-width: 720px) {
+  .app {
+    padding: 1.5rem;
+  }
+
+  .round-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .app-footer {
+    text-align: left;
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState } from 'react'
+import './App.css'
+import {
+  approveSong,
+  createRoom,
+  createSong,
+  getCurrentRound,
+  joinRoom,
+  listSongs,
+  rejectSong,
+  sendSkip,
+  startRound,
+  submitGuess,
+  fetchRoom,
+} from './api/client'
+import AdminSongManager from './components/AdminSongManager'
+import GameDashboard from './components/GameDashboard'
+import RoomSetup from './components/RoomSetup'
+
+function App() {
+  const [roomCode, setRoomCode] = useState('')
+  const [room, setRoom] = useState(null)
+  const [player, setPlayer] = useState(null)
+  const [currentRound, setCurrentRound] = useState(null)
+  const [approvedSongs, setApprovedSongs] = useState([])
+  const [pendingSongs, setPendingSongs] = useState([])
+  const [adminToken, setAdminToken] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [startingRound, setStartingRound] = useState(false)
+  const [feedback, setFeedback] = useState('')
+  const [error, setError] = useState('')
+  const [adminError, setAdminError] = useState('')
+
+  const refreshSongs = useCallback(async () => {
+    try {
+      const [approved, pending] = await Promise.all([
+        listSongs({ status: 'approved' }),
+        listSongs({ status: 'pending' }),
+      ])
+      setApprovedSongs(approved)
+      setPendingSongs(pending)
+      setAdminError('')
+    } catch (err) {
+      setAdminError(err.message)
+    }
+  }, [])
+
+  useEffect(() => {
+    refreshSongs()
+  }, [refreshSongs])
+
+  const refreshRoomState = useCallback(async () => {
+    if (!roomCode) {
+      return
+    }
+    try {
+      const updated = await fetchRoom(roomCode)
+      setRoom(updated)
+      setPlayer((prev) => {
+        if (!prev) return prev
+        const found = updated.players.find((entry) => entry.id === prev.id)
+        return found ? { ...prev, ...found } : prev
+      })
+      setError('')
+    } catch (err) {
+      setError(err.message)
+    }
+  }, [roomCode])
+
+  const refreshCurrentRound = useCallback(
+    async ({ revealAnswer = false } = {}) => {
+      if (!roomCode) {
+        return
+      }
+      try {
+        const round = await getCurrentRound(roomCode, { revealAnswer })
+        setCurrentRound(round)
+        setError('')
+      } catch (err) {
+        if (err.message.includes('No active round')) {
+          setCurrentRound(null)
+        } else {
+          setError(err.message)
+        }
+      }
+    },
+    [roomCode],
+  )
+
+  useEffect(() => {
+    if (!roomCode) {
+      return
+    }
+    const interval = setInterval(() => {
+      refreshRoomState()
+      refreshCurrentRound()
+    }, 5000)
+    return () => clearInterval(interval)
+  }, [roomCode, refreshRoomState, refreshCurrentRound])
+
+  const handleCreateRoom = async ({ host_name, target_score, round_duration_seconds }) => {
+    try {
+      setLoading(true)
+      setError('')
+      const response = await createRoom({
+        host_name,
+        target_score,
+        round_duration_seconds,
+      })
+      setRoom(response.room)
+      setPlayer(response.player)
+      setRoomCode(response.room.code)
+      setFeedback(`房間 ${response.room.code} 建立成功！分享房間碼給朋友一起玩吧。`)
+      const round = await getCurrentRound(response.room.code).catch(() => null)
+      setCurrentRound(round)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleJoinRoom = async ({ code, nickname }) => {
+    try {
+      setLoading(true)
+      setError('')
+      const response = await joinRoom(code, { nickname })
+      setRoom(response.room)
+      setPlayer(response.player)
+      setRoomCode(response.room.code)
+      setFeedback(`歡迎加入房間 ${response.room.code}！`)
+      const round = await getCurrentRound(response.room.code).catch(() => null)
+      setCurrentRound(round)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleStartRound = async (songId) => {
+    if (!roomCode) return
+    try {
+      setStartingRound(true)
+      const payload = songId ? { song_id: songId } : {}
+      const round = await startRound(roomCode, payload)
+      setCurrentRound(round)
+      setFeedback('新的一題開始囉！')
+      await refreshRoomState()
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setStartingRound(false)
+    }
+  }
+
+  const handleSubmitGuess = async (guessText) => {
+    if (!roomCode || !player || !currentRound) return
+    try {
+      const response = await submitGuess(roomCode, currentRound.id, {
+        player_id: player.id,
+        guess_text: guessText,
+      })
+      setPlayer((prev) => (prev ? { ...prev, score: response.player_score } : prev))
+      setFeedback(
+        response.is_correct
+          ? `太棒了！你答對了，相似度 ${(response.similarity * 100).toFixed(0)}%。`
+          : `相似度 ${(response.similarity * 100).toFixed(0)}%，再試一次！`,
+      )
+      await refreshRoomState()
+      if (response.round_status !== 'playing') {
+        await refreshCurrentRound({ revealAnswer: true })
+      } else {
+        await refreshCurrentRound()
+      }
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const handleSkipRound = async () => {
+    if (!roomCode || !player || !currentRound) return
+    try {
+      const result = await sendSkip(roomCode, currentRound.id, { player_id: player.id })
+      setFeedback(`已送出跳過票數：${result.skip_votes} / ${result.total_players}`)
+      if (result.round_status !== 'playing') {
+        await refreshCurrentRound({ revealAnswer: true })
+        await refreshRoomState()
+      } else {
+        setCurrentRound((prev) =>
+          prev ? { ...prev, skip_votes: result.skip_votes, total_players: result.total_players } : prev,
+        )
+      }
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const handleRevealAnswer = async () => {
+    await refreshCurrentRound({ revealAnswer: true })
+  }
+
+  const handleCreateSong = async (payload) => {
+    if (!adminToken.trim()) return
+    try {
+      setAdminError('')
+      await createSong(payload, adminToken)
+      await refreshSongs()
+      setFeedback('題庫已更新！')
+    } catch (err) {
+      setAdminError(err.message)
+    }
+  }
+
+  const handleApproveSong = async (songId) => {
+    if (!adminToken.trim()) return
+    try {
+      setAdminError('')
+      await approveSong(songId, adminToken)
+      await refreshSongs()
+    } catch (err) {
+      setAdminError(err.message)
+    }
+  }
+
+  const handleRejectSong = async (songId) => {
+    if (!adminToken.trim()) return
+    try {
+      setAdminError('')
+      await rejectSong(songId, adminToken)
+      await refreshSongs()
+    } catch (err) {
+      setAdminError(err.message)
+    }
+  }
+
+  const isInGame = Boolean(room && player)
+
+  return (
+    <main className="app">
+      {!isInGame ? (
+        <RoomSetup onCreateRoom={handleCreateRoom} onJoinRoom={handleJoinRoom} isLoading={loading} error={error} />
+      ) : (
+        <>
+          <GameDashboard
+            room={room}
+            player={player}
+            currentRound={currentRound}
+            onStartRound={handleStartRound}
+            onSubmitGuess={handleSubmitGuess}
+            onSkipRound={handleSkipRound}
+            onRevealAnswer={handleRevealAnswer}
+            isStartingRound={startingRound}
+            feedback={feedback}
+            error={error}
+            approvedSongs={approvedSongs}
+          />
+          {player?.is_host ? (
+            <AdminSongManager
+              adminToken={adminToken}
+              onAdminTokenChange={setAdminToken}
+              onCreateSong={handleCreateSong}
+              onApproveSong={handleApproveSong}
+              onRejectSong={handleRejectSong}
+              pendingSongs={pendingSongs}
+              approvedSongs={approvedSongs}
+              onRefresh={refreshSongs}
+              error={adminError}
+            />
+          ) : null}
+        </>
+      )}
+    </main>
+  )
+}
+
+export default App

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,148 @@
+const DEFAULT_API_PORT = 8000
+
+function resolveDefaultApiBaseUrl() {
+  const configured = import.meta.env.VITE_API_BASE_URL
+  if (configured && configured.trim().length > 0) {
+    return configured.trim()
+  }
+
+  if (typeof window === 'undefined') {
+    return `http://localhost:${DEFAULT_API_PORT}`
+  }
+
+  const { protocol, hostname } = window.location
+  if (!hostname) {
+    return `http://localhost:${DEFAULT_API_PORT}`
+  }
+
+  const normalizedProtocol = protocol || 'http:'
+  const isStandardPort =
+    (normalizedProtocol === 'http:' && DEFAULT_API_PORT === 80) ||
+    (normalizedProtocol === 'https:' && DEFAULT_API_PORT === 443)
+
+  if (isStandardPort) {
+    return `${normalizedProtocol}//${hostname}`
+  }
+
+  return `${normalizedProtocol}//${hostname}:${DEFAULT_API_PORT}`
+}
+
+const API_BASE_URL = resolveDefaultApiBaseUrl()
+
+async function apiFetch(path, { method = 'GET', body, headers, signal } = {}) {
+  const requestHeaders = {
+    'Content-Type': 'application/json',
+    ...(headers ?? {}),
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers: requestHeaders,
+    body: body ? JSON.stringify(body) : undefined,
+    signal,
+  })
+
+  if (response.status === 204) {
+    return null
+  }
+
+  const text = await response.text()
+  const payload = text ? JSON.parse(text) : null
+
+  if (!response.ok) {
+    const detail = payload?.detail || payload?.message || response.statusText
+    throw new Error(detail)
+  }
+
+  return payload
+}
+
+export function createRoom(payload) {
+  return apiFetch('/rooms', { method: 'POST', body: payload })
+}
+
+export function fetchRoom(code, { signal } = {}) {
+  return apiFetch(`/rooms/${encodeURIComponent(code)}`, { signal })
+}
+
+export function joinRoom(code, payload) {
+  return apiFetch(`/rooms/${encodeURIComponent(code)}/join`, {
+    method: 'POST',
+    body: payload,
+  })
+}
+
+export function startRound(code, payload) {
+  return apiFetch(`/rooms/${encodeURIComponent(code)}/start_round`, {
+    method: 'POST',
+    body: payload,
+  })
+}
+
+export async function getCurrentRound(code, { revealAnswer = false } = {}) {
+  try {
+    return await apiFetch(
+      `/rooms/${encodeURIComponent(code)}/rounds/current?reveal_answer=${revealAnswer ? 'true' : 'false'}`,
+    )
+  } catch (error) {
+    if (error.message.includes('No active round')) {
+      return null
+    }
+    throw error
+  }
+}
+
+export function submitGuess(code, roundId, payload) {
+  return apiFetch(`/rooms/${encodeURIComponent(code)}/rounds/${roundId}/guess`, {
+    method: 'POST',
+    body: payload,
+  })
+}
+
+export function sendSkip(code, roundId, payload) {
+  return apiFetch(`/rooms/${encodeURIComponent(code)}/rounds/${roundId}/skip`, {
+    method: 'POST',
+    body: payload,
+  })
+}
+
+export function getLeaderboard(code) {
+  return apiFetch(`/rooms/${encodeURIComponent(code)}/leaderboard`)
+}
+
+export function listSongs({ status } = {}) {
+  const query = status ? `?status=${encodeURIComponent(status)}` : ''
+  return apiFetch(`/songs${query}`)
+}
+
+export function createSong(payload, adminToken) {
+  return apiFetch('/admin/songs', {
+    method: 'POST',
+    body: payload,
+    headers: { 'X-Admin-Token': adminToken },
+  })
+}
+
+export function updateSong(songId, payload, adminToken) {
+  return apiFetch(`/admin/songs/${songId}`, {
+    method: 'PATCH',
+    body: payload,
+    headers: { 'X-Admin-Token': adminToken },
+  })
+}
+
+export function approveSong(songId, adminToken) {
+  return apiFetch(`/admin/songs/${songId}/approve`, {
+    method: 'POST',
+    headers: { 'X-Admin-Token': adminToken },
+  })
+}
+
+export function rejectSong(songId, adminToken) {
+  return apiFetch(`/admin/songs/${songId}/reject`, {
+    method: 'POST',
+    headers: { 'X-Admin-Token': adminToken },
+  })
+}
+
+export { API_BASE_URL }

--- a/frontend/src/components/AdminSongManager.jsx
+++ b/frontend/src/components/AdminSongManager.jsx
@@ -1,0 +1,128 @@
+import { useState } from 'react'
+
+function AdminSongManager({
+  adminToken,
+  onAdminTokenChange,
+  onCreateSong,
+  onApproveSong,
+  onRejectSong,
+  pendingSongs,
+  approvedSongs,
+  onRefresh,
+  error,
+}) {
+  const [title, setTitle] = useState('')
+  const [animeTitle, setAnimeTitle] = useState('')
+  const [youtubeUrl, setYoutubeUrl] = useState('')
+  const [autoApprove, setAutoApprove] = useState(true)
+  const [notes, setNotes] = useState('')
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    if (!title.trim() || !animeTitle.trim() || !youtubeUrl.trim()) {
+      return
+    }
+    onCreateSong({
+      title: title.trim(),
+      anime_title: animeTitle.trim(),
+      youtube_url: youtubeUrl.trim(),
+      notes: notes.trim() || undefined,
+      status: autoApprove ? 'approved' : 'pending',
+    })
+    setTitle('')
+    setAnimeTitle('')
+    setYoutubeUrl('')
+    setNotes('')
+  }
+
+  return (
+    <section className="card admin-panel">
+      <header>
+        <h2>題庫管理</h2>
+        <button type="button" className="secondary" onClick={onRefresh}>
+          重新整理清單
+        </button>
+      </header>
+      {error ? <div className="error-banner">{error}</div> : null}
+      <div className="admin-panel__grid">
+        <form onSubmit={handleSubmit} className="admin-panel__form">
+          <h3>新增歌曲</h3>
+          <label>
+            管理者 Token
+            <input value={adminToken} onChange={(event) => onAdminTokenChange(event.target.value)} />
+          </label>
+          <label>
+            歌曲名稱 / 歌手
+            <input value={title} onChange={(event) => setTitle(event.target.value)} required />
+          </label>
+          <label>
+            對應動畫名稱
+            <input value={animeTitle} onChange={(event) => setAnimeTitle(event.target.value)} required />
+          </label>
+          <label>
+            YouTube 連結或影片 ID
+            <input value={youtubeUrl} onChange={(event) => setYoutubeUrl(event.target.value)} required />
+          </label>
+          <label>
+            備註 (選填)
+            <input value={notes} onChange={(event) => setNotes(event.target.value)} />
+          </label>
+          <label className="checkbox">
+            <input
+              type="checkbox"
+              checked={autoApprove}
+              onChange={(event) => setAutoApprove(event.target.checked)}
+            />
+            直接核可（取消勾選將進入審核）
+          </label>
+          <button type="submit" disabled={!adminToken.trim()}>
+            新增歌曲
+          </button>
+        </form>
+        <div className="admin-panel__lists">
+          <div>
+            <h3>待審核 ({pendingSongs.length})</h3>
+            {pendingSongs.length === 0 ? <p className="muted">目前沒有待審核的歌曲。</p> : null}
+            <ul>
+              {pendingSongs.map((song) => (
+                <li key={song.id}>
+                  <div>
+                    <strong>{song.title}</strong>
+                    <span>{song.anime_title}</span>
+                  </div>
+                  <div className="admin-panel__list-actions">
+                    <button type="button" onClick={() => onApproveSong(song.id)}>
+                      核可
+                    </button>
+                    <button type="button" className="secondary" onClick={() => onRejectSong(song.id)}>
+                      拒絕
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3>已核可 ({approvedSongs.length})</h3>
+            {approvedSongs.length === 0 ? <p className="muted">請先新增或核可題目。</p> : null}
+            <ul>
+              {approvedSongs.map((song) => (
+                <li key={song.id}>
+                  <div>
+                    <strong>{song.title}</strong>
+                    <span>{song.anime_title}</span>
+                  </div>
+                  <a href={song.youtube_url} target="_blank" rel="noreferrer">
+                    前往影片
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default AdminSongManager

--- a/frontend/src/components/GameDashboard.jsx
+++ b/frontend/src/components/GameDashboard.jsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useState } from 'react'
+import { API_BASE_URL } from '../api/client'
+
+function GameDashboard({
+  room,
+  player,
+  currentRound,
+  onStartRound,
+  onSubmitGuess,
+  onSkipRound,
+  onRevealAnswer,
+  isStartingRound,
+  feedback,
+  error,
+  approvedSongs,
+}) {
+  const [guessText, setGuessText] = useState('')
+  const [selectedSongId, setSelectedSongId] = useState('')
+  const [videoRefreshKey, setVideoRefreshKey] = useState(0)
+
+  useEffect(() => {
+    setGuessText('')
+    setVideoRefreshKey((key) => key + 1)
+  }, [currentRound?.id])
+
+  useEffect(() => {
+    if (!approvedSongs.length) {
+      setSelectedSongId('')
+      return
+    }
+    const fallback = approvedSongs[0]?.id?.toString() ?? ''
+    setSelectedSongId((value) => (value ? value : fallback))
+  }, [approvedSongs])
+
+  const youtubeEmbedSrc = useMemo(() => {
+    if (!currentRound?.song?.youtube_video_id) {
+      return null
+    }
+    const startSeconds = currentRound.song.start_time_seconds || 0
+    const autoplay = 1
+    return `https://www.youtube.com/embed/${currentRound.song.youtube_video_id}?start=${startSeconds}&autoplay=${autoplay}`
+  }, [currentRound])
+
+  const handleGuessSubmit = (event) => {
+    event.preventDefault()
+    if (!guessText.trim() || !currentRound) {
+      return
+    }
+    onSubmitGuess(guessText.trim())
+    setGuessText('')
+  }
+
+  const handleStartRound = () => {
+    onStartRound(selectedSongId ? Number(selectedSongId) : undefined)
+  }
+
+  const handleReplay = () => {
+    setVideoRefreshKey((key) => key + 1)
+  }
+
+  const isRoundActive = currentRound && currentRound.status === 'playing'
+
+  return (
+    <div className="dashboard">
+      <header className="dashboard__header">
+        <div>
+          <h1>房間 {room.code}</h1>
+          <p>
+            目標分數 {room.target_score} 分 ・ 每題 {room.round_duration_seconds} 秒 ・ 人數上限 {room.max_players}
+          </p>
+        </div>
+        <div className="dashboard__host-actions">
+          <span className="badge">你是：{player.nickname}</span>
+          {player.is_host ? <span className="badge badge--host">房主</span> : null}
+        </div>
+      </header>
+
+      {error ? <div className="error-banner">{error}</div> : null}
+      {feedback ? <div className="info-banner">{feedback}</div> : null}
+
+      <section className="card scoreboard">
+        <h2>玩家列表</h2>
+        <ul>
+          {room.players.map((entry) => (
+            <li key={entry.id} className={entry.id === player.id ? 'me' : undefined}>
+              <span>
+                {entry.nickname}
+                {entry.is_host ? <span className="badge badge--host">房主</span> : null}
+              </span>
+              <span className="score">{entry.score} 分</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {room.status === 'finished' ? (
+        <section className="card status-card">
+          <h2>遊戲結束 🎉</h2>
+          <p>
+            {room.winning_player_id
+              ? `獲勝者：${room.players.find((p) => p.id === room.winning_player_id)?.nickname ?? '未知玩家'}`
+              : '本局已結束'}
+          </p>
+        </section>
+      ) : null}
+
+      {player.is_host ? (
+        <section className="card host-controls">
+          <h2>房主控制</h2>
+          <div className="host-controls__content">
+            <div>
+              <label>
+                指定題目（可選）
+                <select value={selectedSongId} onChange={(event) => setSelectedSongId(event.target.value)}>
+                  <option value="">隨機播放一首已核可歌曲</option>
+                  {approvedSongs.map((song) => (
+                    <option value={song.id} key={song.id}>
+                      {song.title} ・ {song.anime_title}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+            <button type="button" onClick={handleStartRound} disabled={isStartingRound || isRoundActive}>
+              {isStartingRound ? '準備中…' : '開始下一題'}
+            </button>
+            {currentRound ? (
+              <button type="button" onClick={() => onRevealAnswer(true)} className="secondary">
+                顯示答案
+              </button>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
+      {currentRound ? (
+        <section className="card round-card">
+          <header className="round-card__header">
+            <div>
+              <h2>第 {currentRound.id} 題</h2>
+              <p>
+                狀態：{translateStatus(currentRound.status)} ・ 跳過 {currentRound.skip_votes} / {currentRound.total_players}
+              </p>
+            </div>
+            <button type="button" onClick={handleReplay} className="secondary">
+              重新播放影片
+            </button>
+          </header>
+          {youtubeEmbedSrc ? (
+            <div className="video-wrapper">
+              <iframe
+                key={videoRefreshKey}
+                src={youtubeEmbedSrc}
+                title="Anime Quiz Song"
+                allow="autoplay; encrypted-media"
+                allowFullScreen
+              />
+            </div>
+          ) : (
+            <p>找不到影片資訊，請確認歌曲設定。</p>
+          )}
+          {currentRound.song?.anime_title ? (
+            <div className="answer-banner">答案：{currentRound.song.anime_title}</div>
+          ) : null}
+          {isRoundActive ? (
+            <form className="guess-form" onSubmit={handleGuessSubmit}>
+              <label>
+                你的答案
+                <input value={guessText} onChange={(event) => setGuessText(event.target.value)} placeholder="請輸入動畫名稱" />
+              </label>
+              <div className="guess-form__actions">
+                <button type="submit" disabled={!guessText.trim()}>
+                  送出答案
+                </button>
+                <button type="button" className="secondary" onClick={onSkipRound}>
+                  我要跳過
+                </button>
+              </div>
+            </form>
+          ) : (
+            <p className="round-complete">
+              {currentRound.winning_player_id
+                ? `由 ${room.players.find((p) => p.id === currentRound.winning_player_id)?.nickname ?? '玩家'} 率先答對！`
+                : '本題已結束，等待房主開始下一題。'}
+            </p>
+          )}
+        </section>
+      ) : (
+        <section className="card round-card">
+          <h2>等待開始</h2>
+          <p>房主可以選擇指定歌曲或直接開始下一題。</p>
+        </section>
+      )}
+
+      <footer className="app-footer">
+        後端服務：<code>{API_BASE_URL}</code>
+      </footer>
+    </div>
+  )
+}
+
+function translateStatus(value) {
+  switch (value) {
+    case 'playing':
+      return '播放中'
+    case 'completed':
+      return '答題完成'
+    case 'skipped':
+      return '已跳過'
+    default:
+      return value
+  }
+}
+
+export default GameDashboard

--- a/frontend/src/components/RoomSetup.jsx
+++ b/frontend/src/components/RoomSetup.jsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+
+function RoomSetup({ onCreateRoom, onJoinRoom, isLoading, error }) {
+  const [hostName, setHostName] = useState('')
+  const [targetScore, setTargetScore] = useState(5)
+  const [roundDuration, setRoundDuration] = useState(120)
+  const [joinCode, setJoinCode] = useState('')
+  const [nickname, setNickname] = useState('')
+
+  const handleCreate = (event) => {
+    event.preventDefault()
+    if (!hostName.trim()) {
+      return
+    }
+    onCreateRoom({
+      host_name: hostName.trim(),
+      target_score: Number(targetScore) || 5,
+      round_duration_seconds: Number(roundDuration) || 120,
+    })
+  }
+
+  const handleJoin = (event) => {
+    event.preventDefault()
+    if (!joinCode.trim() || !nickname.trim()) {
+      return
+    }
+    onJoinRoom({
+      code: joinCode.trim().toUpperCase(),
+      nickname: nickname.trim(),
+    })
+  }
+
+  return (
+    <div className="setup-container">
+      <h1 className="app-title">Anime Quiz App</h1>
+      <p className="app-subtitle">建立房間或透過房間碼加入，一起挑戰猜歌遊戲！</p>
+      {error ? <div className="error-banner">{error}</div> : null}
+      <div className="setup-grid">
+        <form className="card" onSubmit={handleCreate}>
+          <h2>建立新房間</h2>
+          <label>
+            房主暱稱
+            <input value={hostName} onChange={(event) => setHostName(event.target.value)} required />
+          </label>
+          <label>
+            目標分數
+            <input
+              type="number"
+              min="1"
+              max="50"
+              value={targetScore}
+              onChange={(event) => setTargetScore(event.target.value)}
+            />
+          </label>
+          <label>
+            每題作答時間 (秒)
+            <input
+              type="number"
+              min="30"
+              max="600"
+              value={roundDuration}
+              onChange={(event) => setRoundDuration(event.target.value)}
+            />
+          </label>
+          <button type="submit" disabled={isLoading}>
+            {isLoading ? '建立中…' : '建立房間'}
+          </button>
+        </form>
+        <form className="card" onSubmit={handleJoin}>
+          <h2>加入房間</h2>
+          <label>
+            房間碼
+            <input value={joinCode} onChange={(event) => setJoinCode(event.target.value)} required />
+          </label>
+          <label>
+            暱稱
+            <input value={nickname} onChange={(event) => setNickname(event.target.value)} required />
+          </label>
+          <button type="submit" disabled={isLoading}>
+            {isLoading ? '加入中…' : '加入遊戲'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default RoomSetup

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,11 @@
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- switch the API schemas to pydantic v2-style validators and ConfigDict with from_attributes for ORM models
- replace legacy BaseModel.from_orm usage with model_validate so SQLModel entities serialize without runtime errors

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68d2b4510f448330ba4fa51352753f93